### PR TITLE
Add systemd service file

### DIFF
--- a/init/hefurd.service
+++ b/init/hefurd.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Hefur BitTorrent tracker
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/hefurd -torrent-dir /var/lib/hefurd
+User=hefur
+Group=hefur
+CPUSchedulingPolicy=batch
+Restart=on-failure
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Include the Arch Linux based systemd service which requires a dedicated
hefur user to run the hefurd service. The service also applies some
systemd hardening dissalowing the service to escalate priviliges.

Closes: #27