### PR TITLE
Fix invalid port set for HTTPS, ignore reverse proxy source ip if "all address" set

### DIFF
--- a/hefur/hefur.cc
+++ b/hefur/hefur.cc
@@ -31,7 +31,7 @@ namespace hefur
     if (HTTPS_PORT != 0 && !CERT.empty() && !KEY.empty())
     {
       https_server_.reset(new HttpServer);
-      https_server_->start(HTTP_PORT, IPV6, CERT, KEY);
+      https_server_->start(HTTPS_PORT, IPV6, CERT, KEY);
     }
 
 #ifdef HEFUR_CONTROL_INTERFACE

--- a/hefur/log-handler.cc
+++ b/hefur/log-handler.cc
@@ -14,9 +14,12 @@ namespace hefur {
       struct sockaddr_in in;
       struct sockaddr_in6 in6;
 
+
       // Are the reverse proxy settings enabled?
       if (!REVERSE_PROXY_FROM.empty() && !REVERSE_PROXY_HEADER.empty() &&
-          REVERSE_PROXY_FROM == original_ip.ipStr()) {
+          (REVERSE_PROXY_FROM == "0.0.0.0" ||
+           REVERSE_PROXY_FROM == "::" ||
+           REVERSE_PROXY_FROM == original_ip.ipStr())) {
          // Does the original IP match the reverse-proxy-from setting?
          auto headers = request.unparsedHeaders();
          auto header = headers.find(REVERSE_PROXY_HEADER);

--- a/hefur/options.cc
+++ b/hefur/options.cc
@@ -97,6 +97,6 @@ namespace hefur
 
   const std::string & REVERSE_PROXY_FROM = *mo::addOption<std::string>(
     "", "reverse-proxy-from",
-    "IP to allow ip parsing from for reverse proxy",
+    "IP to allow ip parsing from for reverse proxy, '0.0.0.0' or '::' to allow from all",
     "");
 }


### PR DESCRIPTION
There was a typo in `HttpServer.start` method for httpS handler, fixes #33 
Also added option to allow from all reverse proxy addresses