### PR TITLE
Dockerfile improvements: add `DEBIAN_FRONTEND=noninteractive`, size and readability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,25 @@
 FROM debian:11-slim
-RUN apt-get update && apt-get install -y build-essential git cmake \
-    libgnutls28-dev libarchive-dev zlib1g-dev protobuf-compiler \
-    libprotobuf-dev libprotoc-dev liblzma-dev bison flex
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN \
+  apt-get update && \
+  apt-get install -y \
+    bison \
+    build-essential \
+    cmake \
+    flex \
+    git \
+    protobuf-compiler \
+    libgnutls28-dev \
+    libarchive-dev \
+    libprotobuf-dev \
+    libprotoc-dev \
+    liblzma-dev \
+    zlib1g-dev \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/
+
 COPY . /src
 WORKDIR /src
 RUN git submodule init && \
@@ -11,8 +29,17 @@ RUN git submodule init && \
     CC=gcc CXX=g++ cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
     DESTDIR=build-root make install
 
+
+
 FROM debian:11-slim
-RUN apt-get update && apt-get install -y libprotobuf23
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN \
+  apt-get update && \
+  apt-get install -y libprotobuf23 && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/
+
 COPY --from=0 /src/build/build-root/ /
 
 EXPOSE 6969


### PR DESCRIPTION
* Add `DEBIAN_FRONTEND=noninteractive` (very recommended)
* Do package cache & index cleanup after `apt-get` (size)
* Readability: expand and sort build deps (grouped by tools & libs).
* Readability: add some spacing between build stages.

Pending (needs feedback after merging this in):
* Add an `ENTRYPOINT`
* Speed up successive, repeated builds by using build cache (useful for development). Sorting build steps by more/less frequently changed files needed.